### PR TITLE
Trim news title when checking for last read news

### DIFF
--- a/src/kalu/news.c
+++ b/src/kalu/news.c
@@ -122,7 +122,7 @@ xml_parser_updates_text (GMarkupParseContext   *context,
     if (streq ("title", list->data))
     {
         /* is this the last item from last check? */
-        if (NULL != config->news_last && streq (config->news_last, text))
+        if (NULL != config->news_last && streq (config->news_last, strtrim(text)))
         {
             parse_updates_data->is_last_reached = TRUE;
             return;
@@ -703,7 +703,7 @@ xml_parser_news_text (GMarkupParseContext *context,
             lists[LIST_TITLES_ALL] = alpm_list_add (lists[LIST_TITLES_ALL], s);
 
             /* is this the last item from last check? */
-            if (NULL != config->news_last && streq (config->news_last, text))
+            if (NULL != config->news_last && streq (config->news_last, strtrim(text)))
             {
                 parse_news_data->is_last_reached = TRUE;
                 return;


### PR DESCRIPTION
The [latest news on archlinux.org](https://www.archlinux.org/feeds/news/) (The end of i686 support) apparently has a space before the title: " The end...". However, the last read news title parsed from news.conf is trimmed, so it won't match the actual news title, causing Kalu to consider every news unread each time it starts.